### PR TITLE
Npm token secret failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,6 +159,9 @@ jobs:
           node-version: 20
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Add `NODE_AUTH_TOKEN` to `setup-node` in `publish.yml` to enable proper npm authentication for publishing.

The `pnpm publish` step was failing because the `setup-node` action was not configuring the `.npmrc` file with the necessary authentication token, despite `NPM_TOKEN` being available as a secret. Passing `NODE_AUTH_TOKEN` to `setup-node` ensures the `.npmrc` is correctly set up.

---
<a href="https://cursor.com/background-agent?bcId=bc-90767133-6385-47ad-8789-e66acc1abff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90767133-6385-47ad-8789-e66acc1abff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

